### PR TITLE
Coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ php:
   - 5.5
   
 before_script:
-  - composer install
+  - composer install --dev
   
-script: phpunit --coverage-text
+script:
+  - mkdir -p build/logs
+  - phpunit -c phpunit.xml.dist
+
+after_script:
+  - php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ php:
   - 5.5
   
 before_script:
-  - composer install --dev
+  - curl -s http://getcomposer.org/installer | php
+  - php composer.phar install --dev --no-interaction
   
 script:
   - mkdir -p build/logs

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ AmCharts web site : [http://www.amcharts.com](http://www.amcharts.com)
 AmCharts examples : [http://www.amcharts.com/javascript-charts](http://www.amcharts.com/javascript-charts)
 
 [![Build Status](https://secure.travis-ci.org/neeckeloo/AmChartsPHP.png?branch=master)](http://travis-ci.org/neeckeloo/AmChartsPHP)
+[![Coverage Status](https://coveralls.io/repos/neeckeloo/AmChartsPHP/badge.png?branch=master)](https://coveralls.io/r/neeckeloo/AmChartsPHP)
 
 Requirements
 ------------

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "zendframework/zend-json": "2.*",
         "zendframework/zend-servicemanager": "2.*"
     },
+    "require-dev": {
+        "satooshi/php-coveralls": "dev-master"
+    },
     "autoload": {
         "psr-0": {
             "AmCharts": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,4 +21,8 @@
             <directory suffix=".php">src/AmCharts</directory>
         </whitelist>
     </filter>
+
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml" />
+    </logging>
 </phpunit>


### PR DESCRIPTION
This PR adds coveralls support (https://coveralls.io/). This tool integrates nicely with both GitHub and Travis, and allows us to keep track of our code coverage.

Coveralls status can be found at https://coveralls.io/r/neeckeloo/AmChartsPHP
